### PR TITLE
Removed deprecated warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
     system: "{{ item.system | default(omit) }}"
     gid: "{{ item.gid | default(omit) }}"
     state: present
-  with_items: genericusers_groups
+  with_items: "{{ genericusers_groups }}"
 
 - name: generic-users | Make sure the users are present
   user:
@@ -20,14 +20,14 @@
     home: "{{ item.home | default(omit) }}"
     system: "{{ item.system | default(omit) }}"
     state: present
-  with_items: genericusers_users
+  with_items: '{{ genericusers_users }}'
 
 - name: generic-users | Install the ssh keys for the users
   authorized_key:
     user: "{{item.0.name}}"
     key: "{{item.1}}"
   with_subelements:
-    - genericusers_users
+    - "{{ genericusers_users }}"
     - ssh_keys
 
 - name: generic-users | Make sure all removed users are not present
@@ -35,10 +35,10 @@
     name: "{{item.name}}"
     state: absent
     remove: yes
-  with_items: genericusers_users_removed
+  with_items: "{{ genericusers_users_removed }}"
 
 - name: generic-users | Make sure all removed groups are not present
   group:
     name: "{{ item.name }}"
     state: absent
-  with_items: genericusers_groups_removed
+  with_items: '{{ genericusers_groups_removed }}'


### PR DESCRIPTION
There was already a pull request for this but it had failed on tests, the reason why was on line 31:

- ssh_keys

Does not need curly brackets