### PR TITLE
Allow to provide primary group for user

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
 - name: generic-users | Make sure the users are present
   user:
     name: "{{ item.name }}"
+    group: "{{ item.group }}"
     groups: "{{ ','.join(item.groups) }}"
     append: "{{ item.append | default(omit) }}"
     password: "{{ item.pass | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: generic-users | Make sure the users are present
   user:
     name: "{{ item.name }}"
-    group: "{{ item.group }}"
+    group: "{{ item.group | default(omit) }}"
     groups: "{{ ','.join(item.groups) }}"
     append: "{{ item.append | default(omit) }}"
     password: "{{ item.pass | default(omit) }}"


### PR DESCRIPTION
I noticed that my home was by default "users" group readable, and figured out that this was because I did not provide a primary group to the user.

This is what is needed to provide the primary group (but I'm not sure how well it plays out if you do not provide `group` though, more testing is required!).
